### PR TITLE
Fix CI workflow for graphviz support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.11', '3.12', '3.13']
+        python-version: ['3.11', '3.12']
 
     steps:
       - name: Check out repository
@@ -21,6 +21,9 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           cache: pip
+
+      - name: Install system dependencies
+        run: sudo apt-get update && sudo apt-get install -y graphviz libgraphviz-dev
 
       - name: Install dependencies
         run: |
@@ -38,7 +41,11 @@ jobs:
       - name: Create golden snapshot if missing
         run: |
           set -euxo pipefail
-          test -f tests/_golden_metrics.json || UPDATE_GOLDEN=1 pytest -q tests/test_golden_metrics.py
+          if [ ! -f tests/_golden_metrics.json ]; then
+            UPDATE_GOLDEN=1 pytest -q tests/test_golden_metrics.py 2>&1 | tee golden.out
+          else
+            echo "golden metrics already exist" | tee golden.out
+          fi
         env:
           PYTHONWARNINGS: default
 


### PR DESCRIPTION
## Summary
- install system graphviz libraries for pygraphviz
- always create golden snapshot artifact and limit Python versions to 3.11 & 3.12

## Testing
- `pytest` *(fails: ImportError: cannot import name 'compute_xi' from 'epistemic_tension')*

------
https://chatgpt.com/codex/tasks/task_e_68aa9ffb05ac8321bdd42493fd4ef610