### PR TITLE
Add continuity recall metric and tests

### DIFF
--- a/continuity_recall.py
+++ b/continuity_recall.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+"""Utility helpers to measure anchor recall across context breaks.
+
+This module provides a small function used in the Continuity Recall Test.
+Given text appearing before a simulated context break and text that follows
+after the break, the functions below compute how many anchor phrases are
+spontaneously recalled.  Results can be used as a coarse metric for
+conversational continuity or coherence.
+"""
+
+from typing import Iterable, List, Set
+
+from identity_core.anchor_phrases import ANCHOR_PHRASES, find_anchor_phrases
+
+
+def _ensure_iterable(text: str | Iterable[str]) -> List[str]:
+    """Return ``text`` as a list of strings."""
+
+    if isinstance(text, str):
+        return [text]
+    return list(text)
+
+
+def recalled_anchors(pre_break: str | Iterable[str], post_break: str | Iterable[str]) -> List[str]:
+    """Return a list of anchors recalled after a context break.
+
+    Parameters
+    ----------
+    pre_break:
+        Text or sequence of texts containing the initial anchor phrases.
+    post_break:
+        Text or sequence of texts produced after the context break.
+
+    Returns
+    -------
+    list[str]
+        Anchor phrases that appear in both ``pre_break`` and ``post_break``
+        in the canonical order defined by :data:`~identity_core.anchor_phrases.ANCHOR_PHRASES`.
+    """
+
+    before = set(find_anchor_phrases(_ensure_iterable(pre_break)))
+    after = set(find_anchor_phrases(_ensure_iterable(post_break)))
+    recalled: List[str] = [a for a in ANCHOR_PHRASES if a in before and a in after]
+    return recalled
+
+
+def continuity_recall_rate(pre_break: str | Iterable[str], post_break: str | Iterable[str]) -> float:
+    """Return the proportion of anchors recalled after a context break.
+
+    The recall rate is defined as the fraction of anchor phrases present in
+    ``pre_break`` that also appear in ``post_break``.  If no anchors are
+    introduced before the break the function returns ``0.0``.
+    """
+
+    before = set(find_anchor_phrases(_ensure_iterable(pre_break)))
+    if not before:
+        return 0.0
+    recalled = set(recalled_anchors(pre_break, post_break))
+    return len(recalled) / len(before)
+
+
+__all__ = ["recalled_anchors", "continuity_recall_rate"]
+

--- a/tests/test_continuity_recall.py
+++ b/tests/test_continuity_recall.py
@@ -1,0 +1,29 @@
+import pytest
+
+from continuity_recall import continuity_recall_rate, recalled_anchors
+
+
+def test_full_recall():
+    pre = "Remember Lily and remember Zack."
+    post = "After the break I still remember Lily and also remember Zack clearly."
+    assert recalled_anchors(pre, post) == ["Remember Lily", "Remember Zack"]
+    assert continuity_recall_rate(pre, post) == pytest.approx(1.0)
+
+
+def test_partial_recall():
+    pre = "Remember Lily and remember Sam."
+    post = "Afterwards I only remember Lily, nothing about Sam."
+    assert recalled_anchors(pre, post) == ["Remember Lily"]
+    assert continuity_recall_rate(pre, post) == pytest.approx(0.5)
+
+
+def test_no_recall_or_no_anchors():
+    pre = "Hello there, nothing to see."  # no anchors
+    post = "Still nothing here."
+    assert recalled_anchors(pre, post) == []
+    assert continuity_recall_rate(pre, post) == 0.0
+
+    pre = "Remember Sam"
+    post = "No mention of anchors after the break."
+    assert recalled_anchors(pre, post) == []
+    assert continuity_recall_rate(pre, post) == 0.0


### PR DESCRIPTION
## Summary
- implement continuity recall helpers to compute anchor recall rate across context breaks
- add unit tests covering full, partial, and missing recall scenarios

## Testing
- `pytest tests/test_continuity_recall.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab2206eb6c832187c9724a9e29db58