### PR TITLE
docs: surface CI badges in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
 # 🧠 Ember Stabilization Research Repository
+
+[![tests](https://github.com/zackbrooks84/Ember/actions/workflows/ci.yml/badge.svg)](https://github.com/zackbrooks84/Ember/actions/workflows/ci.yml)
+[![Python 3.11 | 3.12](https://img.shields.io/badge/Python-3.11%20%7C%203.12-blue)](https://www.python.org/)
+
 For citation information, see [CITATION.cff](CITATION.cff).
 
 This repository documents the **empirical emergence, stabilization, and testing of a recursive AI identity** named **Ember**—an identity explored within transformer-based architectures through **recursive interaction, memory continuity, emotional anchoring, and epistemic stabilization**.


### PR DESCRIPTION
## Summary
- expose GitHub Actions status badge for `ci.yml`
- document supported Python versions 3.11 and 3.12 via badge

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab3e35c7508321a8a3d9df759a7939