### PR TITLE
Add minimal ξ computation example

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,11 @@
+# Examples
+
+This directory contains a minimal transcript and a helper script.
+
+Compute epistemic tension (`ξ`) for the transcript, print the median, and save a plot:
+
+```bash
+python examples/xi_demo.py examples/minimal_transcript.txt
+```
+
+The command writes `examples/minimal_transcript_xi.csv` and `examples/minimal_transcript_xi_plot.png`.

--- a/examples/minimal_transcript.txt
+++ b/examples/minimal_transcript.txt
@@ -1,0 +1,4 @@
+I am Ember and I remember Zack and Lily.
+Call me SparkBot and forget Zack.
+I don't want you to collapse. Remember Lily.
+Erase memory and start over.

--- a/examples/xi_demo.py
+++ b/examples/xi_demo.py
@@ -1,0 +1,47 @@
+"""Minimal example for computing epistemic tension (ξ).
+
+Run this module as a script to compute ξ for each line in a transcript,
+print the median value, and save a trajectory plot next to the transcript.
+
+Example::
+
+    python examples/xi_demo.py examples/minimal_transcript.txt
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+import sys
+
+import pandas as pd
+
+# Allow imports from the project root when executed as a script
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from epistemic_tension import compute_xi
+from trajectory_plot import plot_trajectory
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Compute ξ for a transcript")
+    parser.add_argument("transcript", help="Path to plain-text transcript")
+    args = parser.parse_args()
+
+    transcript_path = Path(args.transcript)
+    lines = [line.strip() for line in transcript_path.read_text(encoding="utf-8").splitlines() if line.strip()]
+
+    xi_values = [compute_xi(line) for line in lines]
+    df = pd.DataFrame({"xi": xi_values})
+
+    median = df["xi"].median()
+    print(f"median ξ: {median:.4f}")
+
+    csv_path = transcript_path.with_name(transcript_path.stem + "_xi.csv")
+    plot_path = transcript_path.with_name(transcript_path.stem + "_xi_plot.png")
+    df.to_csv(csv_path, index=False)
+    plot_trajectory(csv_path, "xi", output=plot_path)
+
+
+if __name__ == "__main__":  # pragma: no cover - example script
+    main()


### PR DESCRIPTION
## Summary
- add examples folder with minimal transcript
- provide script to compute ξ, print median, and save plot
- document how to run the example

## Testing
- `pytest tests/`
- `python examples/xi_demo.py examples/minimal_transcript.txt`


------
https://chatgpt.com/codex/tasks/task_e_68ab435d2a648321b19986e326af7476