### PR TITLE
Streamline test dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,11 @@ pip install -r requirements.txt  # or `pip-sync` / `uv pip sync` with a lock fil
 pytest tests/
 ```
 
+The default ``requirements.txt`` keeps dependencies minimal.  Optional features
+such as cosine-based ξ metrics or graph/PDF utilities require extra packages
+(`sentence-transformers`, `PyMuPDF`, `pygraphviz`, etc.) which can be installed
+separately when needed.
+
 For fully deterministic environments, generate and honor a lock file using
 [`pip-tools`](https://pip-tools.readthedocs.io) (`pip-compile` + `pip-sync`) or
 [`uv`](https://docs.astral.sh/uv/) (`uv pip compile` + `uv pip sync`).

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,14 @@
-# Exact version pins. For deterministic installs consider
-# generating a lock file via `pip-compile` (pip-tools) or `uv pip compile`.
+# Minimal dependencies required to run the test suite.
+#
+# This project has a few optional features that rely on heavier third-party
+# libraries such as ``sentence-transformers``, ``PyMuPDF``, ``scikit-learn`` and
+# ``pygraphviz``.  Those packages are not needed for the core modules or the
+# tests, so they are omitted here to keep installation light-weight. Install
+# them separately if you intend to use the related functionality.
+
+# Exact version pins. For deterministic installs consider generating a lock
+# file via `pip-compile` (pip-tools) or `uv pip compile`.
+
 numpy==1.26.4
 pandas==2.1.4
-scikit-learn==1.3.2
 matplotlib==3.7.2
-PyMuPDF==1.22.5
-sentence-transformers==2.2.2
-pygraphviz==1.14


### PR DESCRIPTION
## Summary
- lighten requirements to only numpy, pandas and matplotlib so `pip install -r requirements.txt` no longer pulls heavy optional libraries
- document optional packages such as sentence-transformers, PyMuPDF and pygraphviz in README

## Testing
- `pip install -r requirements.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aba66973a08321a828184182603f45