### PR TITLE
Pin requirements and skip pygraphviz on Windows

### DIFF
--- a/requirements-dev-light.txt
+++ b/requirements-dev-light.txt
@@ -1,9 +1,9 @@
 # requirements-dev-light.txt — LIGHT dev (builds on light runtime)
 -r requirements-light.txt
 
-pytest>=8.1
-pytest-cov>=4.1
+pytest==8.4.1
+pytest-cov==6.2.1
 
-black>=24.4
-isort>=5.13
-flake8>=7.0
+black==25.1.0
+isort==6.0.1
+flake8==7.3.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,10 +1,10 @@
 # requirements-dev.txt — FULL dev (builds on full runtime)
 -r requirements.txt
 
-pytest>=8.1
-pytest-cov>=4.1
-hypothesis>=6.100
+pytest==8.4.1
+pytest-cov==6.2.1
+hypothesis==6.138.3
 
-black>=24.4
-isort>=5.13
-flake8>=7.0
+black==25.1.0
+isort==6.0.1
+flake8==7.3.0

--- a/requirements-light.txt
+++ b/requirements-light.txt
@@ -1,8 +1,8 @@
 # requirements-light.txt — LIGHT runtime (fast install)
-numpy>=1.26
-pandas>=2.1
-matplotlib>=3.8
-regex>=2024.5
-jsonschema>=4.21
-click>=8.1
-rapidfuzz>=3.5
+numpy==2.3.2
+pandas==2.3.2
+matplotlib==3.10.5
+regex==2025.7.34
+jsonschema==4.25.1
+click==8.2.1
+rapidfuzz==3.13.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,25 +1,26 @@
 # Core numerics & data
-numpy>=1.26
-scipy>=1.11
-pandas>=2.1
-matplotlib>=3.8
-tqdm>=4.66
-regex>=2024.5
-jsonschema>=4.21
-click>=8.1
-networkx>=3.2
-Pillow>=10.3
+numpy==2.3.2
+scipy==1.16.1
+pandas==2.3.2
+matplotlib==3.10.5
+tqdm==4.67.1
+regex==2025.7.34
+jsonschema==4.25.1
+click==8.2.1
+networkx==3.5
+Pillow==11.3.0
 
 # Text similarity / distance
-rapidfuzz>=3.5
-python-Levenshtein>=0.25
+rapidfuzz==3.13.0
+python-Levenshtein==0.27.1
 
 # PDF parsing
-PyMuPDF>=1.24
+PyMuPDF==1.26.3
 
 # Embeddings & sentence similarity
-sentencepiece>=0.1.99
-sentence-transformers>=2.7.0
+sentencepiece==0.2.1
+sentence-transformers==5.1.0
 
 # Graph & figure utilities
-pygraphviz>=1.12
+pygraphviz==1.14 ; platform_system != 'Windows'
+


### PR DESCRIPTION
## Summary
- Pin core and development requirements to exact versions for reproducible installs
- Skip `pygraphviz` on Windows using an environment marker to avoid missing wheels
- Update light and dev requirements to reference the pinned versions

## Testing
- `pytest` *(fails: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68abd89537888321aae99cab814dfee3