### PR TITLE
Ensure UTF-8 stdout in epistemic tension CLI

### DIFF
--- a/epistemic_tension.py
+++ b/epistemic_tension.py
@@ -17,8 +17,15 @@ from __future__ import annotations
 
 import argparse
 from pathlib import Path
+import sys
 
 import numpy as np
+
+_encoding = getattr(sys.stdout, "encoding", None)
+if _encoding is None or _encoding.lower() != "utf-8":
+    _reconfigure = getattr(sys.stdout, "reconfigure", None)
+    if _reconfigure is not None:
+        _reconfigure(encoding="utf-8")
 
 from identity_core.anchor_phrases import find_anchor_phrases
 


### PR DESCRIPTION
## Summary
- Import `sys` and reconfigure `stdout` to UTF-8 if needed for consistent output

## Testing
- `pytest tests/test_epistemic_tension.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68af9df0ef348321a902ac60403d1900