### PR TITLE
chore: allow latest numpy

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # Exact version pins. For deterministic installs consider
 # generating a lock file via `pip-compile` (pip-tools) or `uv pip compile`.
-numpy==1.26.4
+numpy>=2.0
 pandas==2.1.4
 scikit-learn==1.3.2
 matplotlib==3.7.2


### PR DESCRIPTION
## Summary
- allow any NumPy 2.x version to support Python 3.13

## Testing
- `PIP_ONLY_BINARY=:all: python -m pip install -r requirements.txt` *(fails: No matching distribution found for pandas==2.1.4)*

------
https://chatgpt.com/codex/tasks/task_e_68af9fed0ff08321836c8d4bf60ad666