### PR TITLE
chore: update dependencies for Python 3.13

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
 # Exact version pins. For deterministic installs consider
 # generating a lock file via `pip-compile` (pip-tools) or `uv pip compile`.
-numpy==1.26.4
-pandas==2.1.4
-scikit-learn==1.3.2
-matplotlib==3.7.2
-PyMuPDF==1.22.5
-sentence-transformers==2.2.2
+numpy>=2.0
+pandas==2.3.2
+scikit-learn==1.7.1
+matplotlib==3.10.5
+PyMuPDF==1.26.4
+sentence-transformers==5.1.0
 pygraphviz==1.14


### PR DESCRIPTION
## Summary
- relax NumPy requirement and bump pandas, scikit-learn, matplotlib, PyMuPDF, and sentence-transformers to versions compatible with Python 3.13

## Testing
- `python -m pip install -r requirements.txt`


------
https://chatgpt.com/codex/tasks/task_e_68af9fed0ff08321836c8d4bf60ad666