### PR TITLE
Register custom drift markers in pytest configuration

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -3,3 +3,5 @@ testpaths = tests
 addopts = -ra
 markers =
     empirical: tests that rely on empirical snapshots/“golden” values
+    low_drift: mark test for low drift scenarios
+    high_drift: mark test for high drift scenarios


### PR DESCRIPTION
## Summary
- add `low_drift` and `high_drift` custom markers for pytest

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68afb1e397588321a1cccea7394ad166