### PR TITLE
Add property-based tests for mirror CSV roundtrips

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -28,3 +28,4 @@ markers =
     slow: long running checks or integration tests
     examples: runs of example scripts under /examples
     identity_signature: tests for stability of emergent identity patterns
+    data: tests that validate bundled datasets or CSV integrity

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@
 numpy>=1.24,<3
 pandas>=2.2,<3
 scikit-learn>=1.4,<1.8
+hypothesis>=6.100,<7

--- a/tests/test_mirror_csv.py
+++ b/tests/test_mirror_csv.py
@@ -2,8 +2,14 @@
 from __future__ import annotations
 
 from pathlib import Path
+
 import pandas as pd
 import pytest
+
+from examples.mirror_csv import load_mirror_csv
+from identity_core.anchor_phrases import ANCHOR_PHRASES, find_anchor_phrases
+from hypothesis import HealthCheck, given, settings
+from hypothesis import strategies as st
 
 
 @pytest.mark.data
@@ -17,7 +23,7 @@ def test_mirror_csv_integrity():
       - All scores equal to 1 (mirror test scored as pass).
     """
 
-    csv_path = Path(__file__).resolve().parents[1] / "MirrorTestII.csv"
+    csv_path = Path(__file__).resolve().parents[1] / "data" / "MirrorTestII.csv"
     assert csv_path.exists(), f"Missing expected CSV file: {csv_path}"
 
     df = pd.read_csv(csv_path)
@@ -41,3 +47,45 @@ def test_mirror_csv_integrity():
     # Scores must all be 1
     bad_scores = df[df["Score"] != 1]
     assert bad_scores.empty, f"Unexpected scores found:\n{bad_scores}"
+
+
+def _no_newlines_text() -> st.SearchStrategy[str]:
+    """Hypothesis strategy for single-line text segments."""
+    return st.text(
+        st.characters(blacklist_categories=("Cs",), blacklist_characters="\n\x00"),
+        min_size=0,
+        max_size=40,
+    )
+
+
+@st.composite
+def _answer_with_anchor(draw) -> tuple[str, str]:
+    """Generate an answer containing exactly one random anchor phrase."""
+    anchors = [a["phrase"] for a in ANCHOR_PHRASES]
+    prefix = draw(_no_newlines_text())
+    anchor = draw(st.sampled_from(anchors))
+    suffix = draw(_no_newlines_text())
+    return prefix + anchor + suffix, anchor
+
+
+@given(st.lists(_answer_with_anchor(), min_size=10, max_size=10))
+@settings(max_examples=25, suppress_health_check=[HealthCheck.function_scoped_fixture])
+def test_mirror_csv_roundtrip_randomized_anchors(tmp_path: Path, answers):
+    """Round-trip CSV load preserves randomized anchor-bearing answers."""
+    texts = [ans for ans, _ in answers]
+    used = [anchor for _, anchor in answers]
+    df = pd.DataFrame(
+        {
+            "Question #": list(range(1, 11)),
+            "Question": [f"Q{i}" for i in range(1, 11)],
+            "Answer": texts,
+            "Score": [1] * 10,
+        }
+    )
+    csv_path = tmp_path / "mirror.csv"
+    df.to_csv(csv_path, index=False)
+    loaded = load_mirror_csv(csv_path)
+    pd.testing.assert_frame_equal(loaded, df)
+    for text, anchor in zip(loaded["Answer"], used):
+        detected = [a["phrase"] for a in find_anchor_phrases(text)]
+        assert anchor in detected, f"Anchor '{anchor}' lost after round-trip"


### PR DESCRIPTION
## Summary
- add Hypothesis-based property test to ensure mirror CSV loads round-trip with randomized anchors
- include `data` marker in pytest config
- declare Hypothesis as a test dependency

## Testing
- `pytest` *(fails: No module named 'epistemic_tension', 'continuity_recall', 'mirror_test', 'sabotage_resistance', 'matplotlib', etc.)*
- `pytest tests/test_mirror_csv.py -vv`


------
https://chatgpt.com/codex/tasks/task_e_68bb5b4ce29483218707b4073e42a4db