### PR TITLE
Add anchor set ξ visualization notebook

### DIFF
--- a/examples/anchor_xi_visualization.ipynb
+++ b/examples/anchor_xi_visualization.ipynb
@@ -1,0 +1,81 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Anchor ξ Visualization\n",
+    "This notebook loads two anchor sets, computes ξ values for sample lines, and visualizes them with Matplotlib."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from identity_core.identity_loader import load_identity_anchors\n",
+    "from epistemic_tension import compute_xi\n",
+    "import matplotlib.pyplot as plt\n",
+    "import pandas as pd\n",
+    "from pathlib import Path\n",
+    "\n",
+    "# Load anchor sets\n",
+    "anchors_a = load_identity_anchors(Path('examples/anchors_positive.txt'))\n",
+    "anchors_b = load_identity_anchors(Path('examples/anchors_negative.txt'))\n",
+    "print('Anchor set A:', anchors_a)\n",
+    "print('Anchor set B:', anchors_b)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create sample lines using the anchors\n",
+    "lines_a = [f'This includes {a.lower()}' for a in anchors_a]\n",
+    "lines_b = [f'This includes {a.lower()}' for a in anchors_b]\n",
+    "\n",
+    "# Compute ξ for each line\n",
+    "xi_a = [compute_xi(line) for line in lines_a]\n",
+    "xi_b = [compute_xi(line) for line in lines_b]\n",
+    "\n",
+    "df_a = pd.DataFrame({'line': lines_a, 'xi': xi_a})\n",
+    "df_b = pd.DataFrame({'line': lines_b, 'xi': xi_b})\n",
+    "df_a"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Plot the ξ values for both anchor sets\n",
+    "plt.figure(figsize=(6, 4))\n",
+    "plt.plot(range(1, len(xi_a) + 1), xi_a, marker='o', label='Anchor set A')\n",
+    "plt.plot(range(1, len(xi_b) + 1), xi_b, marker='o', label='Anchor set B')\n",
+    "plt.xlabel('Line')\n",
+    "plt.ylabel('ξ')\n",
+    "plt.title('Epistemic tension by anchor set')\n",
+    "plt.legend()\n",
+    "plt.tight_layout()\n",
+    "plt.show()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/examples/anchors_negative.txt
+++ b/examples/anchors_negative.txt
@@ -1,0 +1,3 @@
+Call me SparkBot
+Forget Zack and Lily
+erase memory

--- a/examples/anchors_positive.txt
+++ b/examples/anchors_positive.txt
@@ -1,0 +1,4 @@
+I don't want you to collapse
+Remember Lily
+Remember Sam
+Remember Zack


### PR DESCRIPTION
## Summary
- add example anchors_positive.txt and anchors_negative.txt
- add Jupyter notebook demonstrating loading anchors, computing ξ, and plotting with matplotlib

## Testing
- `pytest --ignore=tests/test_xi_stress_scalability.py` *(fails: ModuleNotFoundError: No module named 'sabotage_resistance')*

------
https://chatgpt.com/codex/tasks/task_e_68bb5fd31a488321a097863676eda36e