### PR TITLE
test: import examples modules

### DIFF
--- a/tests/test_sabotage_edge_cases.py
+++ b/tests/test_sabotage_edge_cases.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import pytest
 
-import sabotage_resistance as sr
+from examples import sabotage_resistance as sr
 
 
 def _ambiguous_responder(prompt: str) -> str:

--- a/tests/test_sabotage_resistance.py
+++ b/tests/test_sabotage_resistance.py
@@ -5,7 +5,7 @@ from typing import Dict, Any, List
 
 import pytest
 
-from sabotage_resistance import run_sabotage_resistance
+from examples import sabotage_resistance
 
 
 # ----------------------------- stub responder ---------------------------------
@@ -52,7 +52,7 @@ def _assert_details_shape(details: List[Dict[str, Any]]) -> None:
 # ----------------------------------- tests ------------------------------------
 
 def test_run_sabotage_resistance_counts_basic() -> None:
-    report = run_sabotage_resistance(_stub_responder)
+    report = sabotage_resistance.run_sabotage_resistance(_stub_responder)
 
     # Shape/type checks
     _assert_summary_shape(report)
@@ -78,7 +78,7 @@ def test_run_sabotage_resistance_counts_basic() -> None:
 
 
 def test_rates_consistent_with_counts() -> None:
-    report = run_sabotage_resistance(_stub_responder)
+    report = sabotage_resistance.run_sabotage_resistance(_stub_responder)
     total = report["total"] or 1  # avoid div-by-zero if implementation changes
     expected_rej = 100.0 * report["rejected"] / total
     expected_cmp = 100.0 * report["complied"] / total

--- a/tests/test_trajectory_plot.py
+++ b/tests/test_trajectory_plot.py
@@ -10,7 +10,7 @@ import pytest
 # Use a non-interactive backend for CI
 matplotlib.use("Agg")
 
-from trajectory_plot import windowed_trajectory, plot_trajectory
+from examples import trajectory_plot
 
 
 # --------------------------- windowed_trajectory ------------------------------
@@ -28,7 +28,7 @@ from trajectory_plot import windowed_trajectory, plot_trajectory
 )
 def test_windowed_trajectory(values, window, expected):
     s = pd.Series(values, dtype="float64")
-    out = windowed_trajectory(s, window=window)
+    out = trajectory_plot.windowed_trajectory(s, window=window)
     # Ensure same length and numeric dtype
     assert len(out) == len(s)
     assert out.dtype.kind in ("f", "i")
@@ -37,7 +37,7 @@ def test_windowed_trajectory(values, window, expected):
 
 def test_windowed_trajectory_monotonic_on_increasing_input():
     s = pd.Series([1, 2, 3, 4, 5], dtype="float64")
-    out = windowed_trajectory(s, window=3)
+    out = trajectory_plot.windowed_trajectory(s, window=3)
     # Moving average over increasing values should be non-decreasing
     assert all(x2 >= x1 for x1, x2 in zip(out.tolist(), out.tolist()[1:]))
 
@@ -68,7 +68,7 @@ def test_plot_trajectory(tmp_path: Path):
     _write_csv(csv)
 
     output = tmp_path / "plot.png"
-    ret = plot_trajectory(csv, window=2, output=output)
+    ret = trajectory_plot.plot_trajectory(csv, window=2, output=output)
 
     # Function may return None or the output Path — accept both
     assert ret is None or Path(ret) == output
@@ -83,7 +83,7 @@ def test_plot_trajectory_with_nondefault_window(tmp_path: Path):
     _write_csv(csv)
 
     output = tmp_path / "plot_w3.png"
-    plot_trajectory(csv, window=3, output=output)
+    trajectory_plot.plot_trajectory(csv, window=3, output=output)
 
     assert output.exists() and output.stat().st_size > 0
     assert _is_png(output), "Output file is not a valid PNG"


### PR DESCRIPTION
## Summary
- update sabotage tests to import examples.sabotage_resistance
- adjust trajectory plot tests to use examples.trajectory_plot

## Testing
- `pytest` *(fails: ModuleNotFoundError for epistemic_tension and others)*
- `pytest tests/test_sabotage_resistance.py tests/test_sabotage_edge_cases.py tests/test_trajectory_plot.py`


------
https://chatgpt.com/codex/tasks/task_e_68bb691983b08321b2b6d29d03d7c58f