### PR TITLE
Add continuity recall example module

### DIFF
--- a/examples/continuity_recall.py
+++ b/examples/continuity_recall.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+"""
+Re-export continuity recall utilities for examples and tests.
+
+This module simply exposes the core functions from
+``identity_core.continuity_recall`` so they can be imported as
+``continuity_recall`` or ``examples.continuity_recall``.
+
+If needed, default logging or other environment setup for examples can
+also live here.
+"""
+
+from identity_core.continuity_recall import (
+    continuity_recall_rate,
+    recalled_anchors,
+)
+
+__all__ = ["recalled_anchors", "continuity_recall_rate"]


### PR DESCRIPTION
## Summary
- add `examples/continuity_recall.py` to re-export continuity recall utilities
- include optional placeholder for example-specific setup

## Testing
- `pytest tests/test_continuity_recall.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68bbaf2367d48321b2b633cef7ee16a6