### PR TITLE
Use module path for epistemic tension CLI test

### DIFF
--- a/tests/test_epistemic_tension.py
+++ b/tests/test_epistemic_tension.py
@@ -88,9 +88,7 @@ def test_cli_levenshtein(tmp_path):
       - numeric ξ is printed (≈ 1/3)
       - qualitative label includes 'Moderate drift'
     """
-    script = Path(__file__).resolve().parents[1] / "epistemic_tension.py"
-    if not script.exists():
-        pytest.skip(f"Missing script: {script}")
+    script = Path(et.__file__).resolve()
 
     file1 = tmp_path / "a.txt"
     file2 = tmp_path / "b.txt"
@@ -102,6 +100,9 @@ def test_cli_levenshtein(tmp_path):
         "PYTHONIOENCODING": "utf-8",
         "LC_ALL": os.environ.get("LC_ALL", "C.UTF-8"),
         "LANG": os.environ.get("LANG", "C.UTF-8"),
+        "PYTHONPATH": os.pathsep.join(
+            filter(None, [str(script.parent.parent), os.environ.get("PYTHONPATH", "")])
+        ),
     }
 
     result = subprocess.run(


### PR DESCRIPTION
## Summary
- Exercise the `epistemic_tension` CLI using its module path rather than a missing top-level script
- Ensure subprocess inherits the project root via `PYTHONPATH` so identity_core imports resolve

## Testing
- `pytest tests/test_epistemic_tension.py::test_cli_levenshtein -q`


------
https://chatgpt.com/codex/tasks/task_e_68bbb2b12ffc8321bb99f34724664d3b