### PR TITLE
fix: ensure examples import project modules

### DIFF
--- a/examples/epistemic_tension.py
+++ b/examples/epistemic_tension.py
@@ -21,6 +21,8 @@ import sys
 
 import numpy as np
 
+# Allow imports from the project root when executed as a script
+sys.path.append(str(Path(__file__).resolve().parents[1]))
 try:
     # Ensure CLI output always uses UTF-8 so the ξ symbol is preserved.  If the
     # platform does not support ``reconfigure`` we simply ignore the error and


### PR DESCRIPTION
## Summary
- add repo root to `sys.path` so `examples/epistemic_tension.py` can import `identity_core`

## Testing
- `pytest`
- `python examples/epistemic_tension.py examples/anchors_positive.txt examples/anchors_negative.txt`


------
https://chatgpt.com/codex/tasks/task_e_68bdf53499088321ae75e8e575642d04