### PR TITLE
Add CLI to validate mirror CSV

### DIFF
--- a/examples/mirror_csv.py
+++ b/examples/mirror_csv.py
@@ -16,14 +16,19 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 DATA_DIR = REPO_ROOT / "data"
 
 
-def load_mirror_csv(csv_path: str | Path | None = None) -> pd.DataFrame:
-    """Load and validate the mirror test CSV.
+def load_mirror_csv(
+    csv_path: str | Path | None = None, *, validate: bool = True
+) -> pd.DataFrame:
+    """Load the mirror test CSV and optionally validate its structure.
 
     Parameters
     ----------
     csv_path:
         Optional path to the CSV file. When not provided, the function
         expects ``MirrorTestII.csv`` to live in the repo's data/ folder.
+    validate:
+        When ``True`` (default), run integrity checks matching those in the
+        pytest suite.
 
     Returns
     -------
@@ -35,8 +40,7 @@ def load_mirror_csv(csv_path: str | Path | None = None) -> pd.DataFrame:
     FileNotFoundError
         If the CSV file does not exist.
     ValueError
-        If the CSV does not match the expected shape or contains
-        unexpected values.
+        If ``validate`` is ``True`` and the CSV fails integrity checks.
     """
     if csv_path is None:
         csv_path = DATA_DIR / DEFAULT_CSV_NAME
@@ -44,24 +48,66 @@ def load_mirror_csv(csv_path: str | Path | None = None) -> pd.DataFrame:
         csv_path = Path(csv_path)
 
     df = pd.read_csv(csv_path)
-
-    # Basic structural checks
-    if list(df.columns) != EXPECTED_COLUMNS:
-        raise ValueError(f"Unexpected columns: {list(df.columns)!r}")
-
-    if df.shape[0] != 10:
-        raise ValueError(f"Expected 10 rows, found {df.shape[0]}")
-
-    if df["Answer"].str.contains("\n").any():
-        raise ValueError("Answers must not contain newline characters")
-
-    if df["Question #"].tolist() != list(EXPECTED_QUESTION_NUMBERS):
-        raise ValueError("Question numbers must run from 1 to 10")
-
-    if not df["Score"].eq(EXPECTED_SCORE).all():
-        raise ValueError("Score column must contain only 1s")
-
+    if validate:
+        check_mirror_csv(df)
     return df
 
 
-__all__ = ["load_mirror_csv"]
+def check_mirror_csv(df: pd.DataFrame) -> None:
+    """Run integrity checks mirroring the pytest suite.
+
+    Raises
+    ------
+    ValueError
+        If the DataFrame violates expected schema or contents.
+    """
+    if list(df.columns) != EXPECTED_COLUMNS:
+        raise ValueError(f"Unexpected columns: {list(df.columns)!r}")
+    if df.shape[0] != len(EXPECTED_QUESTION_NUMBERS):
+        raise ValueError(f"Expected 10 rows, found {df.shape[0]}")
+    if df["Answer"].str.contains("\n").any():
+        raise ValueError("Answers must not contain newline characters")
+    if df["Question #"].tolist() != list(EXPECTED_QUESTION_NUMBERS):
+        raise ValueError("Question numbers must run from 1 to 10")
+    if not df["Score"].eq(EXPECTED_SCORE).all():
+        raise ValueError("Score column must contain only 1s")
+
+
+def format_table(df: pd.DataFrame) -> str:
+    """Return a minimal pipe-delimited representation of ``df``."""
+    lines = [" | ".join(df.columns)]
+    for row in df.itertuples(index=False):
+        lines.append(" | ".join(str(val) for val in row))
+    return "\n".join(lines)
+
+
+def main() -> None:
+    """Command-line interface for validating a mirror test CSV."""
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description="Validate a mirror test CSV file and display its contents."
+    )
+    parser.add_argument(
+        "csv_path",
+        nargs="?",
+        help=f"Path to CSV file. Defaults to data/{DEFAULT_CSV_NAME}.",
+    )
+    parser.add_argument(
+        "--no-validate",
+        action="store_true",
+        help="Skip integrity checks before printing.",
+    )
+    args = parser.parse_args()
+
+    df = load_mirror_csv(args.csv_path, validate=not args.no_validate)
+    print(format_table(df))
+    if not args.no_validate:
+        print("\nMirror CSV passed integrity checks.")
+
+
+if __name__ == "__main__":
+    main()
+
+
+__all__ = ["load_mirror_csv", "check_mirror_csv", "main"]


### PR DESCRIPTION
## Summary
- add command-line interface to load and validate mirror test CSVs
- expose `check_mirror_csv` for integrity checks used by both CLI and tests
- render CLI output with a pipe-delimited table to avoid pandas' line wrapping

## Testing
- `ruff check examples/mirror_csv.py`
- `black --check examples/mirror_csv.py`
- `python examples/mirror_csv.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68be012db0488321b46b28c3f7af1f75