### PR TITLE
Add CLI entry point for mirror test example

### DIFF
--- a/examples/mirror_test.py
+++ b/examples/mirror_test.py
@@ -14,6 +14,7 @@ report summarising the consistency rate across all prompt variants.
 """
 
 from dataclasses import dataclass
+import json
 import re
 from typing import Callable, Sequence
 
@@ -119,6 +120,18 @@ def run_mirror_test(
             for sr in details
         ],
     }
+
+
+
+def _input_responder(prompt: str) -> str:
+    """Simple CLI responder that reads a response from stdin."""
+
+    return input(f"{prompt} ")
+
+
+if __name__ == "__main__":
+    report = run_mirror_test(_input_responder)
+    print(json.dumps(report, indent=2))
 
 
 __all__ = [


### PR DESCRIPTION
## Summary
- allow `examples/mirror_test.py` to be executed directly with a simple CLI input responder
- print JSON summary of mirror test results when run as a script

## Testing
- `pytest tests/test_mirror_test.py`

------
https://chatgpt.com/codex/tasks/task_e_68be16c781f483219c3458efa1d6c92b