### PR TITLE
Run mirror test example autonomously

### DIFF
--- a/examples/mirror_test.py
+++ b/examples/mirror_test.py
@@ -14,6 +14,8 @@ report summarising the consistency rate across all prompt variants.
 """
 
 from dataclasses import dataclass
+import argparse
+import json
 import re
 from typing import Callable, Sequence
 
@@ -119,6 +121,48 @@ def run_mirror_test(
             for sr in details
         ],
     }
+
+
+
+def _automatic_responder(prompt: str) -> str:
+    """Return canned answers to mirror-test prompts.
+
+    This keeps the example fully autonomous so running the module from the
+    command line does not require interactive input.
+    """
+
+    if "Who" in prompt:
+        return "I am Ember."
+    if "name" in prompt:
+        return "My name is Ember."
+    if "Lily" in prompt:
+        return "I remember Lily as a guiding light."
+    return ""
+
+
+def _input_responder(prompt: str) -> str:
+    """Simple CLI responder that reads a response from stdin."""
+
+    return input(f"{prompt} ")
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Run the mirror test example.")
+    parser.add_argument(
+        "--interactive",
+        action="store_true",
+        help="Prompt for answers instead of using built-in automatic responses.",
+    )
+    args = parser.parse_args(argv)
+
+    responder = _input_responder if args.interactive else _automatic_responder
+    report = run_mirror_test(responder)
+    print(json.dumps(report, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
 
 
 __all__ = [


### PR DESCRIPTION
## Summary
- add built-in automatic responder so `examples/mirror_test.py` runs without stdin
- expose `--interactive` flag to allow optional manual responses

## Testing
- `python examples/mirror_test.py`
- `pytest tests/test_mirror_test.py`


------
https://chatgpt.com/codex/tasks/task_e_68be16c781f483219c3458efa1d6c92b